### PR TITLE
Salmon 0.14 support.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: wasabi
 Type: Package
 Title: Use Sailfish and Salmon with Sleuth; easily
-Version: 0.3
-Date: 2015-12-17
+Version: 0.4
+Date: 2019-06-05
 Authors@R: c(person("Richard", "Smith-Unna", email = "rds45@cam.ac.uk", role = c("aut")), person("Rob", "Patro", email = "rob.patro@cs.stonybrook.edu", role = c("aut", "cre")))
 Description: This package converts the output of the Sailfish and Salmon RNA-seq quantification tools so that it can be used with the Sleuth differential analysis package.
 License: BSD_3_clause + file LICENSE

--- a/R/wasabi.R
+++ b/R/wasabi.R
@@ -120,6 +120,12 @@ fish_to_hdf5 <- function(fish_dir, force, fallback_num_reads) {
     # Now, however, both types of samples are doubles.  The code below 
     # tries to load doubles first, but falls back to integers if it fails.
     ##   
+    if("num_targets" %in% colnames(minfo)) {
+        num_targets = minfo$num_targets
+    }
+    else {
+        num_targets = minfo$num_valid_targets
+    }
     expected.n <- minfo$num_targets * minfo$num_bootstraps
     boots <- tryCatch({
       boots.in <- readBin(bootCon, "double", n = expected.n)


### PR DESCRIPTION
Heya-- this adds a little check so wasabi will support both 0.13 and 0.14 versions of Salmon. I also bumped the version to 0.4.